### PR TITLE
chore: mss依存の追加 (Closes #24)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pynput>=1.7.6          # For global input capture (minimum version for stability)
 pillow>=10.0.0         # For screenshot and image processing
 cryptography>=41.0.0   # For macro file encryption
+mss>=9                 # For fast, lightweight screen capture (Linux/CI fallback)
 pywin32>=306; platform_system == "Windows"  # Windows専用依存（GDIなどWinAPI用）
 # tkinter は各OSのPython配布に含まれるが、Linuxでは python3-tk パッケージが必要
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,6 +34,13 @@ class TestDependencyIntegration(unittest.TestCase):
                 except ImportError as e:
                     self.fail(f"Failed to import required dependency '{dep}': {e}")
 
+    def test_mss_importable(self):
+        """`mss` がインポート可能であることを確認"""
+        try:
+            import mss  # noqa: F401
+        except ImportError as e:
+            self.fail(f"Failed to import required dependency 'mss': {e}")
+
     def test_pynput_specific_version(self):
         """Test that pynput is the expected version"""
 


### PR DESCRIPTION
目的:
- Linux/CI 環境での画面キャプチャ安定化に向け、軽量な mss を依存として追加しました。

変更点:
- requirements.txt に `mss>=9` を追加
- tests/test_integration.py に `mss` のインポート検証テストを追加

検証:
- .venv 上で `pip install -r requirements.txt` 成功
- `python -c "import mss; print(mss.__version__)"` -> 10.1.0 を確認
- `pytest -q tests/test_integration.py::TestDependencyIntegration::test_mss_importable` パス
- `ruff check .` / `ruff format . --check` は問題なし

補足:
- リポジトリ全体の pytest 実行で 1 件の既知/無関係な失敗がありました（`tests/test_input_capture.py::TestInputCaptureManager::test_continuous_recording_display`）。本PRの依存追加とは無関係のため別Issueで追跡するのが適切です。

このPRがマージされると Issue #24 は自動的にクローズされます。

Closes #24
